### PR TITLE
Modify cursor color in Cherry Blossom terminal theme

### DIFF
--- a/Cherry Blossom/terminal/foot/Cherry Blossom dark
+++ b/Cherry Blossom/terminal/foot/Cherry Blossom dark
@@ -1,6 +1,3 @@
-[cursor]
-color=2A1B21 EFDCE8
-
 [colors]
 foreground=F3C7D7
 background=2A1922
@@ -25,3 +22,4 @@ bright7=d8e0ff
 
 selection-foreground=2A1B21
 selection-background=F2C1D4
+cursor=2A1B21 EFDCE8


### PR DESCRIPTION
Updated cursor color settings in terminal configuration for foot according to Baba
the problem was apparently i was using outdated syntax.
"it gave me a warning that the cursor part was deprecated and threw the fix for me" -Baba