### PR TITLE
GruvboxAlt theme - Light mode primary color update

### DIFF
--- a/GruvboxAlt/GruvboxAlt.json
+++ b/GruvboxAlt/GruvboxAlt.json
@@ -18,7 +18,7 @@
         "mOnHover": "#282828"
     },
     "light": {
-        "mPrimary": "#282828" ,
+        "mPrimary": "#3c3836",
         "mOnPrimary": "#fbf1c7",
         "mSecondary": "#689d6a",
         "mOnSecondary": "#fbf1c7",


### PR DESCRIPTION
Subtle but important change, made the light theme primary color slightly softer.
<img width="614" height="321" alt="image" src="https://github.com/user-attachments/assets/ec4a3a8f-1c00-4bce-bb40-2ed46155ec38" />
