### PR TITLE
tweak to on primary to support both as background and text on red.

### DIFF
--- a/Occult Umbral/Occult Umbral.json
+++ b/Occult Umbral/Occult Umbral.json
@@ -1,7 +1,7 @@
 {
   "dark": {
     "mPrimary": "#8B2E2E",
-    "mOnPrimary": "#E4DED2",
+    "mOnPrimary": "#1C1C28",
     "mSecondary": "#8BAA82",
     "mOnSecondary": "#0A0A12",
     "mTertiary": "#9A7398",


### PR DESCRIPTION
fix for discord announcement background. ( material theme requires mOnPrimary work as a background for this element ) 