### PR TITLE
Adwaita color scheme

### DIFF
--- a/ADW/ADW.json
+++ b/ADW/ADW.json
@@ -1,0 +1,94 @@
+{
+    "dark": {
+        "mPrimary": "#3584e4",
+        "mOnPrimary": "#ffffff",
+        "mSecondary": "#ffffff",
+        "mOnSecondary": "#ffffff",
+        "mTertiary": "#26a269",
+        "mOnTertiary": "#ffffff",
+        "mError": "#c01c28",
+        "mOnError": "#ffffff",
+        "mSurface": "#242424",
+        "mOnSurface": "#ffffff",
+        "mHover": "#3584e4",
+        "mOnHover": "#ffffff",
+        "mSurfaceVariant": "#1e1e1e",
+        "mOnSurfaceVariant": "#ffffff",
+        "mOutline": "#3d3846",
+        "mShadow": "#000000",
+        "terminal": {
+            "background": "#1e1e1e",
+            "foreground": "#ffffff",
+            "cursor": "#3584e4",
+            "cursorText": "#ffffff",
+            "selectionBackground": "#3584e4",
+            "selectionForeground": "#ffffff",
+            "normal": {
+                "black": "#241f31",
+                "red": "#c01c28",
+                "green": "#2ec27e",
+                "yellow": "#f5c211",
+                "blue": "#1e78e4",
+                "magenta": "#9841bb",
+                "cyan": "#0ab9dc",
+                "white": "#c0bfbc"
+            },
+            "bright": {
+                "black": "#5e5c64",
+                "red": "#ed333b",
+                "green": "#57e389",
+                "yellow": "#f8e45c",
+                "blue": "#51a1ff",
+                "magenta": "#c061cb",
+                "cyan": "#4fd2fd",
+                "white": "#ffffff"
+            }
+        }
+    },
+    "light": {
+        "mPrimary": "#3584e4",
+        "mOnPrimary": "#ffffff",
+        "mSecondary": "#2e3436",
+        "mOnSecondary": "#ffffff",
+        "mTertiary": "#2ec27e",
+        "mOnTertiary": "#ffffff",
+        "mError": "#e01b24",
+        "mOnError": "#ffffff",
+        "mSurface": "#fafafa",
+        "mOnSurface": "#2e3436",
+        "mHover": "#3584e4",
+        "mOnHover": "#ffffff",
+        "mSurfaceVariant": "#ffffff",
+        "mOnSurfaceVariant": "#2e3436",
+        "mOutline": "#d6d6d6",
+        "mShadow": "#000000",
+        "terminal": {
+            "background": "#ffffff",
+            "foreground": "#2e3436",
+            "cursor": "#3584e4",
+            "cursorText": "#ffffff",
+            "selectionBackground": "#3584e4",
+            "selectionForeground": "#ffffff",
+            "normal": {
+                "black": "#171421",
+                "red": "#c01c28",
+                "green": "#26a269",
+                "yellow": "#a2734c",
+                "blue": "#12488b",
+                "magenta": "#a347ba",
+                "cyan": "#2aa1b3",
+                "white": "#d0cfcc"
+            },
+            "bright": {
+                "black": "#5e5c64",
+                "red": "#f66151",
+                "green": "#33d17a",
+                "yellow": "#e5a50a",
+                "blue": "#3584e4",
+                "magenta": "#c061cb",
+                "cyan": "#33c7de",
+                "white": "#ffffff"
+            }
+        }
+    }
+}


### PR DESCRIPTION
I am sending a rough draft of an Adwaita color scheme for Noctalia, for the workspaces and clock widget to show its intended color please use color 2 to test
<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/3e9ec11d-9b40-414e-ae58-18c3ffcee784" />

<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/feb8c37c-7964-4481-a2ff-b5baa1d22f90" />
Control center


<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/58d75fbd-78ac-4a1b-aa11-4a603467ffb5" />
Launcher


<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/2a3a9a0a-9ea8-496f-aede-084a78467ff6" />
Power menu


<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/020c9fcc-aa68-4749-b60a-2365bfaebf98" />
Settings


<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/f4574fd2-0992-4276-8b44-819a54b40177" />
Recomended desktop switcher color settings

<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/d168a92b-e8b2-45bd-a90a-bdff8d71c811" />
Recomended clock colors

<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/334c3aba-e3f0-4ca6-a7fe-182dbf2a85d5" />
Light theme

<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/d7ba7113-76da-4e14-bc91-34d26ae17855" />
Light theme settings

<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/c4425663-3b19-4912-bd0b-46b90c3b833d" />
Light theme launcher