### PR TITLE
fix(workflow): Only run the registry workflow on the main repository and not on forks.

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: ${{ github.repository == 'noctalia-dev/community-palettes' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This should fix it so that people don't send in the registry and it doesn't update on their side.