### PR TITLE
feat: add Flexoki colorscheme

### DIFF
--- a/Flexoki/Flexoki.json
+++ b/Flexoki/Flexoki.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mSurface": "#100f0f",
+    "mOnSurface": "#cecdc3",
+    "mSurfaceVariant": "#1c1b1a",
+    "mOnSurfaceVariant": "#878580",
+    "mPrimary": "#879a39",
+    "mOnPrimary": "#1a1e0c",
+    "mSecondary": "#4385be",
+    "mOnSecondary": "#101a24",
+    "mTertiary": "#8b7ec8",
+    "mOnTertiary": "#1a1623",
+    "mError": "#d14d41",
+    "mOnError": "#261312",
+    "mHover": "#403e3c",
+    "mOnHover": "#cecdc3",
+    "mOutline": "#282726",
+    "mShadow": "#100f0f",
+    "terminal": {
+      "background": "#100f0f",
+      "foreground": "#cecdc3",
+      "cursor": "#cecdc3",
+      "cursorText": "#100f0f",
+      "selectionBg": "#164f4a",
+      "selectionFg": "#ddf1e4",
+      "normal": {
+        "black": "#343331",
+        "red": "#d14d41",
+        "green": "#879a39",
+        "yellow": "#d0a215",
+        "blue": "#4385be",
+        "magenta": "#8b7ec8",
+        "cyan": "#3aa99f",
+        "white": "#e6e4d9"
+      },
+      "bright": {
+        "black": "#575653",
+        "red": "#f89a8a",
+        "green": "#bec97e",
+        "yellow": "#eccb60",
+        "blue": "#92bfdb",
+        "magenta": "#c4b9e0",
+        "cyan": "#87d3c3",
+        "white": "#fffcf0"
+      }
+    }
+  },
+  "light": {
+    "mSurface": "#fffcf0",
+    "mOnSurface": "#100f0f",
+    "mSurfaceVariant": "#f2f0e5",
+    "mOnSurfaceVariant": "#6f6e69",
+    "mPrimary": "#879a39",
+    "mOnPrimary": "#1a1e0c",
+    "mSecondary": "#4385be",
+    "mOnSecondary": "#101a24",
+    "mTertiary": "#8b7ec8",
+    "mOnTertiary": "#1a1623",
+    "mError": "#d14d41",
+    "mOnError": "#261312",
+    "mHover": "#cecdc3",
+    "mOnHover": "#100f0f",
+    "mOutline": "#e6e4d9",
+    "mShadow": "#100f0f",
+    "terminal": {
+      "background": "#fffcf0",
+      "foreground": "#100f0f",
+      "cursor": "#100f0f",
+      "cursorText": "#fffcf0",
+      "selectionBg": "#a2dece",
+      "selectionFg": "#101f1d",
+      "normal": {
+        "black": "#343331",
+        "red": "#af3029",
+        "green": "#66800b",
+        "yellow": "#ad8301",
+        "blue": "#205ea6",
+        "magenta": "#5e409d",
+        "cyan": "#24837b",
+        "white": "#cecdc3"
+      },
+      "bright": {
+        "black": "#6f6e69",
+        "red": "#d14d41",
+        "green": "#879a39",
+        "yellow": "#d0a215",
+        "blue": "#4385be",
+        "magenta": "#8b7ec8",
+        "cyan": "#3aa99f",
+        "white": "#f2f0e5"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a new colorscheme based on Steph Ango's Flexoki palette.

The official Flexoki specification treats accent colors purely as small UI accents, which causes eye strain in dense terminal environments (e.g., using accent-600 as a normal text color is too harsh).

To solve this, terminal colors in this patch use scaled contrast for readability:

- Dark mode:
  - *normal* uses 400-series (soft baseline)
  - *bright* uses 200-series (lighter highlights)

- Light mode:
  - *normal* uses 600-series (deep ink to prevent wash-out)
  - *bright* uses 400-series (vibrant highlights)

Grayscale values are also semantically mapped (bright.black matches mOnSurfaceVariant for legible comments), and light mode text selection uses a custom pastel mint to emulate a physical highlighter.

Noctalia's accent colors are all mapped to accent-400 for best readability in both dark and light variants.

See: https://stephango.com/flexoki

## Screenshots

### Dark theme

<img width="3831" height="2160" alt="dark" src="https://github.com/user-attachments/assets/d8e501fd-9281-4616-b625-512924cfd198" />

---

<img width="3831" height="2160" alt="dark-1" src="https://github.com/user-attachments/assets/b5168783-ad47-4fac-8efc-54ccfab73946" />

---

<img width="3831" height="2160" alt="dark-2" src="https://github.com/user-attachments/assets/2b885265-c706-40af-b057-ac8abe41269b" />


### Light theme

<img width="3831" height="2160" alt="light" src="https://github.com/user-attachments/assets/4c96c499-e12d-4aa4-a0db-544f2ceeeaa8" />

---

<img width="3831" height="2160" alt="light-3" src="https://github.com/user-attachments/assets/e406dfd7-a9bb-439f-a048-6b04def4e0aa" />

---

<img width="3831" height="2160" alt="light-2" src="https://github.com/user-attachments/assets/9fd0b22e-4e20-4181-9a61-816610a080be" />


## Checklist

- [x] I have tested my palette in Noctalia with the **dark** theme
- [x] I have tested my palette in Noctalia with the **light** theme
- [x] Screenshots for both themes are attached above
