### PR TITLE
Add Ayu color variants

### DIFF
--- a/Ayu Blue/Ayu Blue.json
+++ b/Ayu Blue/Ayu Blue.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#39BAE6",
+    "mOnPrimary": "#0B0E14",
+    "mSecondary": "#AAD94C",
+    "mOnSecondary": "#0B0E14",
+    "mTertiary": "#E6B450",
+    "mOnTertiary": "#0B0E14",
+    "mError": "#D95757",
+    "mOnError": "#0B0E14",
+    "mSurface": "#0B0E14",
+    "mOnSurface": "#D1D1C7",
+    "mSurfaceVariant": "#1E222A",
+    "mOnSurfaceVariant": "#8E959E",
+    "mOutline": "#565B66",
+    "mShadow": "#000000",
+    "terminal": {
+      "normal": {
+        "black": "#171B24",
+        "red": "#ED8274",
+        "green": "#87D96C",
+        "yellow": "#6DCBFA",
+        "blue": "#FACC6E",
+        "magenta": "#DABAFA",
+        "cyan": "#90E1C6",
+        "white": "#C7C7C7"
+      },
+      "bright": {
+        "black": "#686868",
+        "red": "#F28779",
+        "green": "#D5FF80",
+        "yellow": "#73D0FF",
+        "blue": "#FFD173",
+        "magenta": "#DFBFFF",
+        "cyan": "#95E6CB",
+        "white": "#FFFFFF"
+      },
+      "foreground": "#D1D1C7",
+      "background": "#1F2430",
+      "selectionFg": "#1F2430",
+      "selectionBg": "#409FFF",
+      "cursorText": "#1F2430",
+      "cursor": "#FFCC66"
+    },
+    "mHover": "#39BAE6",
+    "mOnHover": "#0B0E14"
+  },
+  "light": {
+    "mPrimary": "#55B4D4",
+    "mOnPrimary": "#F8F9FA",
+    "mSecondary": "#86B300",
+    "mOnSecondary": "#F8F9FA",
+    "mTertiary": "#FF8F40",
+    "mOnTertiary": "#F8F9FA",
+    "mError": "#E65050",
+    "mOnError": "#F8F9FA",
+    "mSurface": "#F8F9FA",
+    "mOnSurface": "#42474C",
+    "mSurfaceVariant": "#E4E6E9",
+    "mOnSurfaceVariant": "#6E757C",
+    "mOutline": "#8A9199",
+    "mShadow": "#F8F9FA",
+    "terminal": {
+      "normal": {
+        "black": "#000000",
+        "red": "#EA6C6D",
+        "green": "#6CBF43",
+        "yellow": "#3199E1",
+        "blue": "#ECA944",
+        "magenta": "#9E75C7",
+        "cyan": "#46BA94",
+        "white": "#BABABA"
+      },
+      "bright": {
+        "black": "#686868",
+        "red": "#F07171",
+        "green": "#86B300",
+        "yellow": "#399EE6",
+        "blue": "#F2AE49",
+        "magenta": "#A37ACC",
+        "cyan": "#4CBF99",
+        "white": "#D1D1D1"
+      },
+      "foreground": "#42474C",
+      "background": "#F8F9FA",
+      "selectionFg": "#F8F9FA",
+      "selectionBg": "#035BD6",
+      "cursorText": "#F8F9FA",
+      "cursor": "#FFAA33"
+    },
+    "mHover": "#55B4D4",
+    "mOnHover": "#F8F9FA"
+  }
+}

--- a/Ayu Green/Ayu Green.json
+++ b/Ayu Green/Ayu Green.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#AAD94C",
+    "mOnPrimary": "#0B0E14",
+    "mSecondary": "#E6B450",
+    "mOnSecondary": "#0B0E14",
+    "mTertiary": "#39BAE6",
+    "mOnTertiary": "#0B0E14",
+    "mError": "#D95757",
+    "mOnError": "#0B0E14",
+    "mSurface": "#0B0E14",
+    "mOnSurface": "#D1D1C7",
+    "mSurfaceVariant": "#1E222A",
+    "mOnSurfaceVariant": "#8E959E",
+    "mOutline": "#565B66",
+    "mShadow": "#000000",
+    "terminal": {
+      "normal": {
+        "black": "#171B24",
+        "red": "#ED8274",
+        "green": "#FACC6E",
+        "yellow": "#87D96C",
+        "blue": "#6DCBFA",
+        "magenta": "#DABAFA",
+        "cyan": "#90E1C6",
+        "white": "#C7C7C7"
+      },
+      "bright": {
+        "black": "#686868",
+        "red": "#F28779",
+        "green": "#FFD173",
+        "yellow": "#D5FF80",
+        "blue": "#73D0FF",
+        "magenta": "#DFBFFF",
+        "cyan": "#95E6CB",
+        "white": "#FFFFFF"
+      },
+      "foreground": "#D1D1C7",
+      "background": "#1F2430",
+      "selectionFg": "#1F2430",
+      "selectionBg": "#409FFF",
+      "cursorText": "#1F2430",
+      "cursor": "#FFCC66"
+    },
+    "mHover": "#AAD94C",
+    "mOnHover": "#0B0E14"
+  },
+  "light": {
+    "mPrimary": "#86B300",
+    "mOnPrimary": "#F8F9FA",
+    "mSecondary": "#FF8F40",
+    "mOnSecondary": "#F8F9FA",
+    "mTertiary": "#55B4D4",
+    "mOnTertiary": "#F8F9FA",
+    "mError": "#E65050",
+    "mOnError": "#F8F9FA",
+    "mSurface": "#F8F9FA",
+    "mOnSurface": "#42474C",
+    "mSurfaceVariant": "#E4E6E9",
+    "mOnSurfaceVariant": "#6E757C",
+    "mOutline": "#8A9199",
+    "mShadow": "#F8F9FA",
+    "terminal": {
+      "normal": {
+        "black": "#000000",
+        "red": "#EA6C6D",
+        "green": "#ECA944",
+        "yellow": "#6CBF43",
+        "blue": "#3199E1",
+        "magenta": "#9E75C7",
+        "cyan": "#46BA94",
+        "white": "#BABABA"
+      },
+      "bright": {
+        "black": "#686868",
+        "red": "#F07171",
+        "green": "#F2AE49",
+        "yellow": "#86B300",
+        "blue": "#399EE6",
+        "magenta": "#A37ACC",
+        "cyan": "#4CBF99",
+        "white": "#D1D1D1"
+      },
+      "foreground": "#42474C",
+      "background": "#F8F9FA",
+      "selectionFg": "#F8F9FA",
+      "selectionBg": "#035BD6",
+      "cursorText": "#F8F9FA",
+      "cursor": "#FFAA33"
+    },
+    "mHover": "#86B300",
+    "mOnHover": "#F8F9FA"
+  }
+}

--- a/Ayu Red/Ayu Red.json
+++ b/Ayu Red/Ayu Red.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#D95757",
+    "mOnPrimary": "#0B0E14",
+    "mSecondary": "#E6B450",
+    "mOnSecondary": "#0B0E14",
+    "mTertiary": "#39BAE6",
+    "mOnTertiary": "#0B0E14",
+    "mError": "#AAD94C",
+    "mOnError": "#0B0E14",
+    "mSurface": "#0B0E14",
+    "mOnSurface": "#D1D1C7",
+    "mSurfaceVariant": "#1E222A",
+    "mOnSurfaceVariant": "#8E959E",
+    "mOutline": "#565B66",
+    "mShadow": "#000000",
+    "terminal": {
+      "normal": {
+        "black": "#171B24",
+        "red": "#FACC6E",
+        "green": "#ED8274",
+        "yellow": "#87D96C",
+        "blue": "#6DCBFA",
+        "magenta": "#DABAFA",
+        "cyan": "#90E1C6",
+        "white": "#C7C7C7"
+      },
+      "bright": {
+        "black": "#686868",
+        "red": "#FFD173",
+        "green": "#F28779",
+        "yellow": "#D5FF80",
+        "blue": "#73D0FF",
+        "magenta": "#DFBFFF",
+        "cyan": "#95E6CB",
+        "white": "#FFFFFF"
+      },
+      "foreground": "#D1D1C7",
+      "background": "#1F2430",
+      "selectionFg": "#1F2430",
+      "selectionBg": "#409FFF",
+      "cursorText": "#1F2430",
+      "cursor": "#FFCC66"
+    },
+    "mHover": "#D95757",
+    "mOnHover": "#0B0E14"
+  },
+  "light": {
+    "mPrimary": "#E65050",
+    "mOnPrimary": "#F8F9FA",
+    "mSecondary": "#FF8F40",
+    "mOnSecondary": "#F8F9FA",
+    "mTertiary": "#55B4D4",
+    "mOnTertiary": "#F8F9FA",
+    "mError": "#86B300",
+    "mOnError": "#F8F9FA",
+    "mSurface": "#F8F9FA",
+    "mOnSurface": "#42474C",
+    "mSurfaceVariant": "#E4E6E9",
+    "mOnSurfaceVariant": "#6E757C",
+    "mOutline": "#8A9199",
+    "mShadow": "#F8F9FA",
+    "terminal": {
+      "normal": {
+        "black": "#000000",
+        "red": "#ECA944",
+        "green": "#EA6C6D",
+        "yellow": "#6CBF43",
+        "blue": "#3199E1",
+        "magenta": "#9E75C7",
+        "cyan": "#46BA94",
+        "white": "#BABABA"
+      },
+      "bright": {
+        "black": "#686868",
+        "red": "#F2AE49",
+        "green": "#F07171",
+        "yellow": "#86B300",
+        "blue": "#399EE6",
+        "magenta": "#A37ACC",
+        "cyan": "#4CBF99",
+        "white": "#D1D1D1"
+      },
+      "foreground": "#42474C",
+      "background": "#F8F9FA",
+      "selectionFg": "#F8F9FA",
+      "selectionBg": "#035BD6",
+      "cursorText": "#F8F9FA",
+      "cursor": "#FFAA33"
+    },
+    "mHover": "#E65050",
+    "mOnHover": "#F8F9FA"
+  }
+}


### PR DESCRIPTION
## Description

Simple color variants of the Ayu color scheme. I like the built-in Ayu, but needed variants to match different wallpapers and moods.

## Screenshots
### Dark theme

<img width="966" height="1093" alt="image" src="https://github.com/user-attachments/assets/0ca94d70-fc9e-4385-8b81-bd5f60fae75b" />
<img width="966" height="1089" alt="image" src="https://github.com/user-attachments/assets/46012e93-5e9f-42bb-9d2e-f850a7d5728e" />
<img width="965" height="1090" alt="image" src="https://github.com/user-attachments/assets/52129c38-93e2-49b4-b620-9d5551903b13" />

### Light theme

<img width="966" height="1092" alt="image" src="https://github.com/user-attachments/assets/372ef752-a11e-4201-b7a8-0d70d0f6d64b" />
<img width="968" height="1089" alt="image" src="https://github.com/user-attachments/assets/7cbea98b-710f-434a-b75e-a4725c9c32f6" />
<img width="1005" height="1127" alt="image" src="https://github.com/user-attachments/assets/03dd35c4-1ec7-4e20-954e-c745d81be3c0" />

## Checklist

- [x] I have tested my palette in Noctalia with the **dark** theme
- [x] I have tested my palette in Noctalia with the **light** theme
- [x] Screenshots for both themes are attached above