### PR TITLE
Add Catppuccin Frappe Lavender

### DIFF
--- a/Catppuccin Frappe Lavender/Catppuccin Frappe Lavender.json
+++ b/Catppuccin Frappe Lavender/Catppuccin Frappe Lavender.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#babbf1",
+    "mOnPrimary": "#303446",
+    "mSecondary": "#8caaee",
+    "mOnSecondary": "#303446",
+    "mTertiary": "#ca9ee6",
+    "mOnTertiary": "#303446",
+    "mError": "#e78284",
+    "mOnError": "#303446",
+    "mSurface": "#303446",
+    "mOnSurface": "#c6d0f5",
+    "mSurfaceVariant": "#414559",
+    "mOnSurfaceVariant": "#a5adce",
+    "mOutline": "#737994",
+    "mShadow": "#232634",
+    "mHover": "#51576d",
+    "mOnHover": "#c6d0f5",
+    "terminal": {
+      "background": "#303446",
+      "foreground": "#c6d0f5",
+      "cursor": "#babbf1",
+      "cursorText": "#303446",
+      "selectionBg": "#626880",
+      "selectionFg": "#c6d0f5",
+      "normal": {
+        "black": "#51576d",
+        "red": "#e78284",
+        "green": "#a6d189",
+        "yellow": "#e5c890",
+        "blue": "#8caaee",
+        "magenta": "#f4b8e4",
+        "cyan": "#81c8be",
+        "white": "#b5bfe2"
+      },
+      "bright": {
+        "black": "#626880",
+        "red": "#e78284",
+        "green": "#a6d189",
+        "yellow": "#e5c890",
+        "blue": "#8caaee",
+        "magenta": "#f4b8e4",
+        "cyan": "#81c8be",
+        "white": "#a5adce"
+      }
+    }
+  },
+  "light": {
+    "mPrimary": "#7287fd",
+    "mOnPrimary": "#eff1f5",
+    "mSecondary": "#1e66f5",
+    "mOnSecondary": "#eff1f5",
+    "mTertiary": "#8839ef",
+    "mOnTertiary": "#eff1f5",
+    "mError": "#d20f39",
+    "mOnError": "#eff1f5",
+    "mSurface": "#eff1f5",
+    "mOnSurface": "#4c4f69",
+    "mSurfaceVariant": "#ccd0da",
+    "mOnSurfaceVariant": "#6c6f85",
+    "mOutline": "#9ca0b0",
+    "mShadow": "#dce0e8",
+    "mHover": "#bcc0cc",
+    "mOnHover": "#4c4f69",
+    "terminal": {
+      "background": "#eff1f5",
+      "foreground": "#4c4f69",
+      "cursor": "#7287fd",
+      "cursorText": "#eff1f5",
+      "selectionBg": "#acb0be",
+      "selectionFg": "#4c4f69",
+      "normal": {
+        "black": "#bcc0cc",
+        "red": "#d20f39",
+        "green": "#40a02b",
+        "yellow": "#df8e1d",
+        "blue": "#1e66f5",
+        "magenta": "#ea76cb",
+        "cyan": "#179299",
+        "white": "#6c6f85"
+      },
+      "bright": {
+        "black": "#acb0be",
+        "red": "#d20f39",
+        "green": "#40a02b",
+        "yellow": "#df8e1d",
+        "blue": "#1e66f5",
+        "magenta": "#ea76cb",
+        "cyan": "#179299",
+        "white": "#5c5f77"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added Catppuccin Frappe Lavender for dark and Latte Lavender for light

## Description

The built-in Catppuccin palette felt a little too contrast-y for someone who just switched from the Nord theme, and I found that the Frappe to be exactly what I wanted. To add on top, Frappe's Lavender color happens to be my favorite color. Latte Lavender variant also added for compatibility for the light variant. 

## Screenshots

Please attach screenshots of your palette applied in Noctalia for both themes:

### Dark theme
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/d205a44d-17d0-4b9b-a691-03d981142023" />

### Light theme
<img width="1919" height="1075" alt="image" src="https://github.com/user-attachments/assets/cc5f5cc6-1b24-437f-9004-16886e553018" />

## Checklist

- [x] I have tested my palette in Noctalia with the **dark** theme
- [x] I have tested my palette in Noctalia with the **light** theme
- [x] Screenshots for both themes are attached above
