### PR TITLE
Add Solarized Osaka color palette

### DIFF
--- a/Solarized Osaka/Solarized-Osaka.json
+++ b/Solarized Osaka/Solarized-Osaka.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#29a298",
+    "mOnPrimary": "#ffffff",
+    "mSecondary": "#db302d",
+    "mOnSecondary": "#ffffff",
+    "mTertiary": "#b28500",
+    "mOnTertiary": "#001419",
+    "mError": "#db302d",
+    "mOnError": "#ffffff",
+    "mSurface": "#001419",
+    "mOnSurface": "#839395",
+    "mSurfaceVariant": "#002c38",
+    "mOnSurfaceVariant": "#637981",
+    "mOutline": "#576d74",
+    "mShadow": "#001014",
+    "mHover": "#576d74",
+    "mOnHover": "#fdf5e2",
+    "terminal": {
+      "background": "#001419",
+      "foreground": "#839395",
+      "cursor": "#839395",
+      "cursorText": "#001419",
+      "selectionBg": "#002c38",
+      "selectionFg": "#839395",
+      "normal": {
+        "black": "#001014",
+        "red": "#db302d",
+        "green": "#849900",
+        "yellow": "#b28500",
+        "blue": "#268bd3",
+        "magenta": "#d23681",
+        "cyan": "#29a298",
+        "white": "#839395"
+      },
+      "bright": {
+        "black": "#576d74",
+        "red": "#db302d",
+        "green": "#849900",
+        "yellow": "#b28500",
+        "blue": "#268bd3",
+        "magenta": "#d23681",
+        "cyan": "#29a298",
+        "white": "#839395"
+      }
+    }
+  },
+  "light": {
+    "mPrimary": "#29a298",
+    "mOnPrimary": "#001419",
+    "mSecondary": "#db302d",
+    "mOnSecondary": "#fdf5e2",
+    "mTertiary": "#b28500",
+    "mOnTertiary": "#001419",
+    "mError": "#db302d",
+    "mOnError": "#fdf5e2",
+    "mSurface": "#fdf5e2",
+    "mOnSurface": "#576d74",
+    "mSurfaceVariant": "#ede7d3",
+    "mOnSurfaceVariant": "#576d74",
+    "mOutline": "#adb7b7",
+    "mShadow": "#cac4b5",
+    "mHover": "#cac4b5",
+    "mOnHover": "#001419",
+    "terminal": {
+      "background": "#fdf5e2",
+      "foreground": "#576d74",
+      "cursor": "#576d74",
+      "cursorText": "#fdf5e2",
+      "selectionBg": "#fdf5e2",
+      "selectionFg": "#576d74",
+      "normal": {
+        "black": "#cac4b5",
+        "red": "#db302d",
+        "green": "#849900",
+        "yellow": "#b28500",
+        "blue": "#268bd3",
+        "magenta": "#d23681",
+        "cyan": "#29a298",
+        "white": "#576d74"
+      },
+      "bright": {
+        "black": "#adb7b7",
+        "red": "#db302d",
+        "green": "#849900",
+        "yellow": "#b28500",
+        "blue": "#268bd3",
+        "magenta": "#d23681",
+        "cyan": "#29a298",
+        "white": "#576d74"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

[Solarized Osaka](https://github.com/craftzdog/solarized-osaka.nvim), originally created by 
craftzdog, also known as devaslife

## Screenshots

### Dark theme
<img width="1920" height="1080" alt="Dark" src="https://github.com/user-attachments/assets/f17ab87b-4c13-4659-a5ad-0127095444d6" />


### Light theme
<img width="1920" height="1080" alt="Light" src="https://github.com/user-attachments/assets/f6b5ae13-c937-4bbf-ae0c-d08a9a3f3a4a" />

## Checklist

- [x] I have tested my palette in Noctalia with the **dark** theme
- [x] I have tested my palette in Noctalia with the **light** theme
- [x] Screenshots for both themes are attached above